### PR TITLE
JDK 7 jarsigner support

### DIFF
--- a/src/main/java/com/wuntee/oter/smali/SmaliWorkshop.java
+++ b/src/main/java/com/wuntee/oter/smali/SmaliWorkshop.java
@@ -223,7 +223,7 @@ public class SmaliWorkshop {
 		//jarsigner -keystore somestore.ks modified-application.apk some-key-name -storepass
 		
 		
-		TerminatingCommand c = new TerminatingCommand(new String[]{"jarsigner", "-keystore", keystore, "-storepass", keystorePassword, jarFile, alias});
+		TerminatingCommand c = new TerminatingCommand(new String[]{"jarsigner", "-digestalg", "SHA1", "-sigalg", "MD5withRSA", "-keystore", keystore, "-storepass", keystorePassword, jarFile, alias});
 		int ret = c.execute();
 		if(ret != 0){
 			String output = "";
@@ -240,8 +240,8 @@ public class SmaliWorkshop {
 		
         int keysize = 1024;
         int validity = 10000;
-        String keyAlgName = "DSA";
-        String sigAlgName = "SHA1WithDSA";
+        String keyAlgName = "RSA";
+        String sigAlgName = "SHA1WithRSA";
 
         CertAndKeyGen keypair = new CertAndKeyGen(keyAlgName, sigAlgName, null);
 


### PR DESCRIPTION
Otertool's "Automatically generate keystore" fails on JDK 7 because of [Issue 19567](https://code.google.com/p/android/issues/detail?id=19567). As JDK 6 is approaching [EOL](http://www.oracle.com/technetwork/java/eol-135779.html), JDK 7 support is important.
